### PR TITLE
Fix auth by calling the right variable

### DIFF
--- a/twitch_listener/listener.py
+++ b/twitch_listener/listener.py
@@ -27,8 +27,8 @@ class connect_twitch(socket):
         # IRC parameters
         self._server = "irc.chat.twitch.tv"
         self._port = 6667
-        self._passString = f"PASS " + oauth + f"\n"
-        self._nameString = f"NICK " + nickname + f"\n"
+        self._passString = f"PASS " + self.oauth + f"\n"
+        self._nameString = f"NICK " + self.nickname + f"\n"
         
 
     def _join_channels(self, channels):


### PR DESCRIPTION
The "Improperly formatted auth" happen when you call the listen() function with a raw token value (ie without starting with "oauth:"). __init__() function verify the construction of the token and add "oauth:" but the wrong variable is called next to this.